### PR TITLE
notejs-application-metadata with npm-tag support

### DIFF
--- a/application-metadata/action.yml
+++ b/application-metadata/action.yml
@@ -35,6 +35,15 @@ outputs:
       The resolved version that the current build can use.
       The version will usually be semver compliant only for releases.
     value: ${{ steps.metadata.outputs.version }}
+  qualifier:
+    description: |
+      A qualifier tag describing this build. It can be used as npm tag.
+      Released semver tag are qualified as 'latest'
+      Other tag are qualified with their own name.
+      Default branch is qualified 'snapshot'
+      Other branches are qualified 'branch-BRANCH_NAME'
+      PR are qualified 'pr-NUMBER'
+      Any other build is qualified 'dev'
 
 runs:
   using: composite
@@ -57,6 +66,7 @@ runs:
         IS_RELEASE=false
         VERSION=0.0.0-SNAPSHOT
         DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
+        QUALIFIER=dev
 
         LATEST_VERSION=${{ steps.latest.outputs.tag }}
         LATEST_VERSION=${LATEST_VERSION#v}
@@ -71,20 +81,26 @@ runs:
           VERSION=${GITHUB_REF#refs/tags/v}
           PUBLISHABLE=$(git merge-base --is-ancestor "$GITHUB_SHA" "origin/$DEFAULT_BRANCH" && echo "true" || echo "false")
           IS_RELEASE="$PUBLISHABLE"
+          QUALIFIER=latest
         elif [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=$(echo ${GITHUB_REF#refs/tags/} | sed -r 's#/+#-#g')
+          QUALIFIER="$VERSION"
         elif [[ $GITHUB_REF == refs/heads/* ]]; then
           BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           if [ "$DEFAULT_BRANCH" = "$BRANCH" ]; then
             VERSION=${LATEST_VERSION%.*}.$((${LATEST_VERSION##*.} + 1))-SNAPSHOT
             PUBLISHABLE=true
+            QUALIFIER=snapshot
           else
             VERSION=branch-$BRANCH
+            QUALIFIER="$VERSION"
           fi
         elif [[ $GITHUB_REF == refs/pull/* ]]; then
           VERSION=pr-${{ github.event.number }}
+          QUALIFIER="$VERSION"
         fi
 
         echo ::set-output name=is-release::$IS_RELEASE
         echo ::set-output name=publishable::$PUBLISHABLE
         echo ::set-output name=version::$VERSION
+        echo ::set-output name=qualifier::$QUALIFIER

--- a/nodejs-application-metadata/action.yml
+++ b/nodejs-application-metadata/action.yml
@@ -1,4 +1,4 @@
-name: Resolve common application metadata
+name: Resolve nodejs application metadata
 description: |
   Resolve common application metadata like the application version or whether it is publishable (by our standards).
 
@@ -13,7 +13,7 @@ description: |
 
     - name: Find application metadata
       id: metadata
-      uses: .github/actions/application-metadata
+      uses: .github/actions/nodejs-application-metadata
   ```
 
 inputs: {}
@@ -35,6 +35,13 @@ outputs:
       The resolved version that the current build can use.
       The version will usually be semver compliant only for releases.
     value: ${{ steps.metadata.outputs.version }}
+  npm-tag:
+    description: |
+      NPM tag to publish package with.
+      Defined on only if publishable
+      Released semver tag are qualified as 'latest'
+      Default branch is qualified 'snapshot'
+    value: ${{ steps.metadata.outputs.npm-tag }}
 
 runs:
   using: composite
@@ -57,6 +64,7 @@ runs:
         IS_RELEASE=false
         VERSION=0.0.0-SNAPSHOT
         DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
+        NPM_TAG=
 
         LATEST_VERSION=${{ steps.latest.outputs.tag }}
         LATEST_VERSION=${LATEST_VERSION#v}
@@ -71,13 +79,15 @@ runs:
           VERSION=${GITHUB_REF#refs/tags/v}
           PUBLISHABLE=$(git merge-base --is-ancestor "$GITHUB_SHA" "origin/$DEFAULT_BRANCH" && echo "true" || echo "false")
           IS_RELEASE="$PUBLISHABLE"
+          NPM_TAG=latest
         elif [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=$(echo ${GITHUB_REF#refs/tags/} | sed -r 's#/+#-#g')
         elif [[ $GITHUB_REF == refs/heads/* ]]; then
           BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           if [ "$DEFAULT_BRANCH" = "$BRANCH" ]; then
-            VERSION=${LATEST_VERSION%.*}.$((${LATEST_VERSION##*.} + 1))-SNAPSHOT
+            VERSION=${LATEST_VERSION%.*}.$((${LATEST_VERSION##*.} + 1))-$(date -u "+%Y%m%d%H%M%S")
             PUBLISHABLE=true
+            NPM_TAG=snapshot
           else
             VERSION=branch-$BRANCH
           fi
@@ -88,3 +98,4 @@ runs:
         echo ::set-output name=is-release::$IS_RELEASE
         echo ::set-output name=publishable::$PUBLISHABLE
         echo ::set-output name=version::$VERSION
+        echo ::set-output name=npm-tag::$NPM_TAG

--- a/nodejs-application-metadata/action.yml
+++ b/nodejs-application-metadata/action.yml
@@ -85,7 +85,7 @@ runs:
         elif [[ $GITHUB_REF == refs/heads/* ]]; then
           BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           if [ "$DEFAULT_BRANCH" = "$BRANCH" ]; then
-            VERSION=${LATEST_VERSION%.*}.$((${LATEST_VERSION##*.} + 1))-$(date -u "+%Y%m%d%H%M%S")
+            VERSION=${LATEST_VERSION%.*}.$((${LATEST_VERSION##*.} + 1))-snapshot.$(date -u "+%Y%m%d%H%M%S")
             PUBLISHABLE=true
             NPM_TAG=snapshot
           else


### PR DESCRIPTION
Crée une nouvelle action pour déterminer les versions d'application dans un format plus compatible avec npm