### PR TITLE
feat: avoid gitleaks script downloads

### DIFF
--- a/scan-secrets/action.yml
+++ b/scan-secrets/action.yml
@@ -3,11 +3,6 @@ description: |
   Scan commits for leaked secrets.
   By default, pull request events will only scan new commits and push events will scan all commits.
 
-# TODO: Improve efficiency of this action:
-#   - Automatically sync. gitleaks.bash & gitleaks.toml from standards to here. See https://github.com/BetaHuhn/repo-file-sync-action
-#   - This should `runs-on: Dockerfile` based on gitleaks official image. Docker pulls in a bash script don't use cache.
-#     - Alternative is to use actions/cache to cache the gitleaks image.
-
 inputs:
   report-retention-days:
     description: Duration in days to preserve reports.
@@ -26,7 +21,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-        curl -sSL https://raw.githubusercontent.com/kronostechnologies/standards/master/bin/gitleaks.bash | bash
+        ${{ github.action_path }}/files/gitleaks.bash ${{ github.action_path }}/files/gitleaks.toml
 
         result=$?
         echo "::set-output name=status::$result"
@@ -40,5 +35,4 @@ runs:
       with:
         name: secrets-scan.sarif
         retention-days: ${{ inputs.report-retention-days }}
-        path: |
-          ${{ inputs.working-directory }}/build/gitleaks/gitleaks.sarif
+        path: ${{ inputs.working-directory }}/build/gitleaks/gitleaks.sarif

--- a/scan-secrets/files/gitleaks.bash
+++ b/scan-secrets/files/gitleaks.bash
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# This file is read by external tools. Do not move.
+# Usage example in external projects:
+#  curl -sSL https://raw.githubusercontent.com/kronostechnologies/standards/master/bin/gitleaks.bash | bash
+
+set -e
+
+BUILD_OUTPUT=build/gitleaks
+CONTAINER_PATH=/repo
+OPTIONS=("--verbose")
+REMOTE_CONFIG=https://raw.githubusercontent.com/kronostechnologies/standards/master/gitleaks.toml
+
+rm -rf $BUILD_OUTPUT
+mkdir -p $BUILD_OUTPUT
+
+list_commits () {
+    git log --left-right --cherry-pick --pretty=format:"%H" "remotes/$1..." > $BUILD_OUTPUT/commits.txt
+
+    if ! grep -q '[^[:space:]]' $BUILD_OUTPUT/commits.txt; then
+        echo "No commits to scan. Exiting."
+        exit 0
+    fi
+
+    OPTIONS+=("--commits-file=$CONTAINER_PATH/$BUILD_OUTPUT/commits.txt")
+}
+
+scan () {
+    docker run --rm \
+        -u "$(id -u):$(id -g)" \
+        -v "$(pwd):$CONTAINER_PATH" \
+        zricethezav/gitleaks:latest \
+        --path="$CONTAINER_PATH" \
+        "$@"
+}
+
+if [ -f "$1" ]; then
+    cp -f "$1" "$BUILD_OUTPUT/gitleaks.toml"
+else
+    [[ -n "$1" ]] && echo "$1 is not a file"
+    curl -s "$REMOTE_CONFIG" -o "$BUILD_OUTPUT/gitleaks.toml"
+fi
+OPTIONS+=("--additional-config=$CONTAINER_PATH/$BUILD_OUTPUT/gitleaks.toml")
+
+if [[ -v CI ]]; then
+    OPTIONS+=("--redact")
+
+    if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+        list_commits "origin/$GITHUB_BASE_REF"
+    fi
+else
+    echo "Scanning unstaged files"
+    scan --unstaged "${OPTIONS[@]}"
+
+    list_commits "origin/$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)"
+fi
+
+echo "Scanning commits"
+scan  -f sarif -o "$BUILD_OUTPUT/gitleaks.sarif" "${OPTIONS[@]}"

--- a/scan-secrets/files/gitleaks.toml
+++ b/scan-secrets/files/gitleaks.toml
@@ -1,0 +1,9 @@
+# This file is read by external tools. Do not move.
+
+[allowlist]
+description = "We do not care about these potential leaks. They are either mock data or dependencies."
+paths = [
+    '''\.yarn/''',
+    '''build/''',
+    '''node_modules/''',
+]


### PR DESCRIPTION
I decided against adding a local Dockerfile or caching. The action executes in ~2s as it is.

Depends on https://github.com/kronostechnologies/standards/pull/87